### PR TITLE
Edge 1.4.2

### DIFF
--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -370,6 +370,7 @@ public:
         output << "\"bytes\":" << mon.byteSent << ",";
         output << "\"bytesUnique\":" << mon.byteSentUnique << ",";
         output << "\"bytesDropped\":" << mon.byteSndDrop << ",";
+        output << "\"msSendBuffer\":" << mon.msSndBuf << ",";
         output << "\"mbitRate\":" << mon.mbpsSendRate;
         output << "},";
         output << "\"recv\": {";
@@ -386,6 +387,7 @@ public:
         output << "\"bytesUnique\":" << mon.byteRecvUnique << ",";
         output << "\"bytesLost\":" << mon.byteRcvLoss << ",";
         output << "\"bytesDropped\":" << mon.byteRcvDrop << ",";
+        output << "\"msRecvBuffer\":" << mon.msRcvBuf << ",";
         output << "\"mbitRate\":" << mon.mbpsRecvRate;
         output << "}";
         output << "}" << endl;

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -525,7 +525,7 @@ int SrtSource::Read(size_t chunk, MediaPacket& pkt, ostream &out_stats)
         pkt.payload.resize(chunk);
 
     const bool need_bw_report = transmit_bw_report && (counter % transmit_bw_report) == transmit_bw_report - 1;
-    const bool need_stats_report = transmit_stats_report && (counter % transmit_stats_report) == transmit_stats_report - 1;
+    const bool need_stats_report = transmit_stats_report && interval_clock::now() > m_last_stats_report + std::chrono::seconds(transmit_stats_report);
 
     if (need_bw_report || need_stats_report)
     {
@@ -535,8 +535,10 @@ int SrtSource::Read(size_t chunk, MediaPacket& pkt, ostream &out_stats)
         {
             if (need_bw_report)
                 cerr << transmit_stats_writer->WriteBandwidth(perf.mbpsBandwidth) << std::flush;
-            if (need_stats_report)
+            if (need_stats_report) {
                 out_stats << transmit_stats_writer->WriteStats(m_sock, perf) << std::flush;
+                m_last_stats_report = interval_clock::now();
+            }
         }
     }
     ++counter;
@@ -574,7 +576,7 @@ int SrtTarget::Write(const char* data, size_t size, int64_t src_time, ostream &o
     }
 
     const bool need_bw_report = transmit_bw_report && (counter % transmit_bw_report) == transmit_bw_report - 1;
-    const bool need_stats_report = transmit_stats_report && (counter % transmit_stats_report) == transmit_stats_report - 1;
+    const bool need_stats_report = transmit_stats_report && interval_clock::now() > m_last_stats_report + std::chrono::seconds(transmit_stats_report);
 
     if (need_bw_report || need_stats_report)
     {
@@ -584,8 +586,10 @@ int SrtTarget::Write(const char* data, size_t size, int64_t src_time, ostream &o
         {
             if (need_bw_report)
                 cerr << transmit_stats_writer->WriteBandwidth(perf.mbpsBandwidth) << std::flush;
-            if (need_stats_report)
+            if (need_stats_report) {
                 out_stats << transmit_stats_writer->WriteStats(m_sock, perf) << std::flush;
+                m_last_stats_report = interval_clock::now();
+            }
         }
     }
     ++counter;

--- a/apps/transmitmedia.hpp
+++ b/apps/transmitmedia.hpp
@@ -14,11 +14,13 @@
 #include <string>
 #include <map>
 #include <stdexcept>
+#include <chrono>
 
 #include "transmitbase.hpp"
 #include <udt.h> // Needs access to CUDTException
 
 using namespace std;
+using interval_clock = std::chrono::steady_clock;
 
 // Trial version of an exception. Try to implement later an official
 // interruption mechanism in SRT using this.
@@ -120,6 +122,8 @@ public:
     }
 
     bool AcceptNewClient() override { return SrtCommon::AcceptNewClient(); }
+protected:
+    interval_clock::time_point m_last_stats_report = interval_clock::now();
 };
 
 class SrtTarget: public Target, public SrtCommon
@@ -156,6 +160,8 @@ public:
         return socket;
     }
     bool AcceptNewClient() override { return SrtCommon::AcceptNewClient(); }
+protected:
+    interval_clock::time_point m_last_stats_report = interval_clock::now();
 };
 
 


### PR DESCRIPTION
Add two buffer stats to json output: 

* https://github.com/Haivision/srt/blob/master/docs/statistics.md#msSndBuf
(timespan of unacknowledged packets in the send buffer)

* https://github.com/Haivision/srt/blob/master/docs/statistics.md#msRcvBuf
(timespan of acknowledged packets in the receive buffer)

Change stats reporting to be based on time
